### PR TITLE
Update Docs for 0.12 Release

### DIFF
--- a/doc/Dockerhub_rapidsai-dev-nightly.md
+++ b/doc/Dockerhub_rapidsai-dev-nightly.md
@@ -1,0 +1,66 @@
+# [NIGHTLY] RAPIDS - Open GPU Data Science
+
+**IMPORTANT:** For our latest stable release please use the [rapidsai/rapidsai-dev](https://hub.docker.com/r/rapidsai/rapidsai-dev) containers.
+
+## What is RAPIDS?
+
+Visit [rapids.ai](http://rapids.ai) for more information.
+
+The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
+
+**NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
+
+## What are RAPIDS NIGHTLY "dev" images?
+
+The `rapidsai/rapidsai-dev-nightly` repo contains nightly docker builds of the latest WIP changes merged into Github repos throughout the day for the next RAPIDS release. These containers are generally considered unstable, and should only be used for development and testing. For our latest stable release, please use the [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai) containers.
+
+Unlike the Docker images in [rapidsai/rapidsai-nightly](https://hub.docker.com/r/rapidsai/rapidsai-nighlty), the devel images are intended to support a RAPIDS developer working on and running RAPIDS from source.  The devel images contain the full source tree for each RAPIDS Github repo, the complete toolchain and dependencies needed to build and test each repo, pre-built unit tests, the build artifacts and git meta-data, the example notebooks and a Jupyter server to run them.  A RAPIDS developer can simply pull a devel image and start experimenting or debugging in a matter of minutes.
+
+#### RAPIDS 0.12 - 4 February 2020
+
+Versions of libraries included in the `0.12` images:
+- `cuDF` [v0.12.0](https://github.com/rapidsai/cudf/tree/v0.12.0), `cuML` [v0.12.0](https://github.com/rapidsai/cuml/tree/v0.12.0), `cuGraph` [v0.12.0](https://github.com/rapidsai/cugraph/tree/v0.12.0), `RMM` [v0.12.0](https://github.com/rapidsai/RMM/tree/v0.12.0), `cuSpatial` [v0.12.0](https://github.com/rapidsai/cuspatial/tree/v0.12.0), `cuxfilter` [v0.12.0](https://github.com/rapidsai/cuxfilter/tree/branch-0.12)
+- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.12-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.12)
+
+### Image Types
+
+The RAPIDS images are based on [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda), and are intended to be drop-in replacements for the corresponding CUDA
+images in order to make it easy to add RAPIDS libraries while maintaining support for existing CUDA applications.
+
+RAPIDS images come in three types, distributed in two different repos:
+
+This repo (rapidsai-dev-nightly), contains the following
+- `devel` - contains the full RAPIDS source tree, pre-built with all artifacts in place, and the compiler toolchain, the debugging tools, the headers and the static libraries for RAPIDS development. <b>Use this image to develop RAPIDS from source.</b>
+
+For smaller RAPIDS Docker images consisting of a full conda-based install and no development toolchain, refer to the `base` or `runtime` images in [rapidsai/rapidsai-nightly](https://hub.docker.com/r/rapidsai/rapidsai-nightly) repo.
+
+### Image Tag Naming Scheme
+
+The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
+```
+0.9-cuda9.2-devel-ubuntu16.04-py3.6
+ ^       ^    ^        ^         ^
+ |       |    type     |         python version
+ |       |             |
+ |       cuda version  |
+ |                     |
+ RAPIDS version        linux version
+```
+
+## Prerequisites
+
+* NVIDIA Pascal™ GPU architecture or better
+* CUDA [9.2](https://developer.nvidia.com/cuda-92-download-archive) or [10.0](https://developer.nvidia.com/cuda-downloads) compatible NVIDIA driver
+* Ubuntu 16.04/18.04 or CentOS 7
+* Docker CE v18+
+* [nvidia-docker](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)) v2+
+
+## Usage
+
+See [usage instructions](https://hub.docker.com/r/rapidsai/rapidsai#usage) for information and replace references to `rapidsai/rapidsai` with `rapidsai/rapidsai-dev-nightly`.
+
+## Where can I get help or file bugs/requests?
+
+For issues with RAPIDS libraries like cuDF, cuML, RMM, cuGraph, or others file an issue in the related GitHub project.
+
+Additional help can be found on [Stack Overflow](https://stackoverflow.com/tags/rapids) or [Google Groups](https://groups.google.com/forum/#!forum/rapidsai).

--- a/doc/Dockerhub_rapidsai-dev-nightly.md
+++ b/doc/Dockerhub_rapidsai-dev-nightly.md
@@ -12,7 +12,7 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 
 ## What are RAPIDS NIGHTLY "dev" images?
 
-The `rapidsai/rapidsai-dev-nightly` repo contains nightly docker builds of the latest WIP changes merged into Github repos throughout the day for the next RAPIDS release. These containers are generally considered unstable, and should only be used for development and testing. For our latest stable release, please use the [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai) containers.
+The `rapidsai/rapidsai-dev-nightly` repo contains nightly docker builds of the latest WIP changes merged into Github repos throughout the day for the next RAPIDS release. These containers are generally considered unstable, and should only be used for development and testing. For our latest stable release, please use the [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai-dev) containers.
 
 Unlike the Docker images in [rapidsai/rapidsai-nightly](https://hub.docker.com/r/rapidsai/rapidsai-nighlty), the devel images are intended to support a RAPIDS developer working on and running RAPIDS from source.  The devel images contain the full source tree for each RAPIDS Github repo, the complete toolchain and dependencies needed to build and test each repo, pre-built unit tests, the build artifacts and git meta-data, the example notebooks and a Jupyter server to run them.  A RAPIDS developer can simply pull a devel image and start experimenting or debugging in a matter of minutes.
 

--- a/doc/Dockerhub_rapidsai-dev.md
+++ b/doc/Dockerhub_rapidsai-dev.md
@@ -8,26 +8,50 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 
 **NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
 
+## What are RAPIDS "dev" images?
+
+Unlike the Docker images in [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai), the devel images are intended to support a RAPIDS developer working on and running RAPIDS from source.  The devel images contain the full source tree for each RAPIDS Github repo, the complete toolchain and dependencies needed to build and test each repo, pre-built unit tests, the build artifacts and git meta-data, the example notebooks and a Jupyter server to run them.  A RAPIDS developer can simply pull a devel image and start experimenting or debugging in a matter of minutes.
+
 ### Current Version
 
-#### RAPIDS 0.10 - 17 October 2019
+#### RAPIDS 0.12 - 4 February 2020
 
-Versions of libraries included in the `0.10` [images](#rapids-10-images):
-- `cuDF` [v0.10.0](https://github.com/rapidsai/cudf/tree/v0.10.0), `cuML` [v0.10.0](https://github.com/rapidsai/cuml/tree/v0.10.0), `cuGraph` [v0.10.0](https://github.com/rapidsai/cugraph/tree/v0.10.0), `RMM` [v0.10.0](https://github.com/rapidsai/RMM/tree/v0.10.0), `cuSpatial` [v0.10.0](https://github.com/rapidsai/cuspatial/tree/v0.10.0)
-- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.10-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.10)
+Versions of libraries included in the `0.12` images:
+- `cuDF` [v0.12.0](https://github.com/rapidsai/cudf/tree/v0.12.0), `cuML` [v0.12.0](https://github.com/rapidsai/cuml/tree/v0.12.0), `cuGraph` [v0.12.0](https://github.com/rapidsai/cugraph/tree/v0.12.0), `RMM` [v0.12.0](https://github.com/rapidsai/RMM/tree/v0.12.0), `cuSpatial` [v0.12.0](https://github.com/rapidsai/cuspatial/tree/v0.12.0), `cuxfilter` [v0.12.0](https://github.com/rapidsai/cuxfilter/tree/branch-0.12)
+- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.12-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.12)
 
-Updates & changes
-- Added cuSpatial, the GPU-accelerated spatial and trajectory data management and analytics library.
-- Added support for CUDA 10.1.
-- Updated containers with `v0.10.0` release of cuDF, cuML, cuGraph, cuStrings, and RMM, as well as updated versions of xgboost, dask-xgboost, and dask-cuda.
+### Former Version
 
+#### RAPIDS 0.11 - 11 December 2019
 
-### Tags
+Versions of libraries included in the `0.11` images:
+- `cuDF` [v0.11.0](https://github.com/rapidsai/cudf/tree/v0.11.0), `cuML` [v0.11.0](https://github.com/rapidsai/cuml/tree/v0.11.0), `cuGraph` [v0.11.0](https://github.com/rapidsai/cugraph/tree/v0.11.0), `RMM` [v0.11.0](https://github.com/rapidsai/RMM/tree/v0.11.0), `cuSpatial` [v0.11.0](https://github.com/rapidsai/cuspatial/tree/v0.11.0)
+- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.11-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.11)
 
-The RAPIDS image is based on the `devel` [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda) image. This means it is a drop-in replacement, making it easy to gain the RAPIDS libraries while maintaining support for existing CUDA applications.
+### Image Types
 
-The `devel` image type in this repo contains RAPIDS source code (complete with git meta-data) built from source and installed into the `rapids` conda environment. These images also contain the compiler toolchain, the debugging tools, and example notebooks needed for RAPIDS development.<br/>Use this image to develop RAPIDS from source.
+The RAPIDS images are based on [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda), and are intended to be drop-in replacements for the corresponding CUDA
+images in order to make it easy to add RAPIDS libraries while maintaining support for existing CUDA applications.
 
+RAPIDS images come in three types, distributed in two different repos:
+
+This repo (rapidsai-dev), contains the following:
+- `devel` - contains the full RAPIDS source tree, pre-built with all artifacts in place, and the compiler toolchain, the debugging tools, the headers and the static libraries for RAPIDS development. <b>Use this image to develop RAPIDS from source.</b>
+
+For smaller RAPIDS Docker images consisting of a full conda-based install and no development toolchain, refer to the `base` or `runtime` images in [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai) repo.
+
+### Image Tag Naming Scheme
+
+The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
+```
+0.9-cuda9.2-devel-ubuntu16.04-py3.6
+ ^       ^    ^        ^         ^
+ |       |    type     |         python version
+ |       |             |
+ |       cuda version  |
+ |                     |
+ RAPIDS version        linux version
+```
 
 ## Prerequisites
 
@@ -43,19 +67,19 @@ The `devel` image type in this repo contains RAPIDS source code (complete with g
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04
+$ docker pull rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04-py3.6-py3.6
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04
-         ```
-         **NOTE:** This will open a shell with [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) running in the background on port 8888 on your host machine.
+         rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04-py3.6
+```
+**NOTE:** This will open a shell with [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) running in the background on port 8888 on your host machine.
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04
+$ docker pull rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04-py3.6
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04
-         ```
-         **NOTE:** This will open a shell with [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) running in the background on port 8888 on your host machine.
+         rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04-py3.6
+```
+**NOTE:** This will open a shell with [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) running in the background on port 8888 on your host machine.
 
 ### Use JupyterLab to Explore the Notebooks
 
@@ -77,17 +101,16 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04
-                  ```
+                  rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04-py3.6
+```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04
-                  ```
-                  This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
-
+                  rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04-py3.6
+```
+This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 
 ### Access Documentation within Notebooks
 
@@ -114,95 +137,3 @@ Please submit issues with the container to this GitHub repository: [https://gith
 For issues with RAPIDS libraries like cuDF, cuML, RMM, or others file an issue in the related GitHub project.
 
 Additional help can be found on [Stack Overflow](https://stackoverflow.com/tags/rapids) or [Google Groups](https://groups.google.com/forum/#!forum/rapidsai).
-
-## Full Tag List
-
-Using the image types [above](#tags) `devel` we use the following
-tag naming scheme for RAPIDS images:
-
-```
-0.10-cuda9.2-devel-ubuntu16.04-py3.6
-^        ^    ^        ^          ^
-|        |    type     |          python version
-|        |             |
-|        cuda version  |
-|                      |
-RAPIDS version         linux version
-```
-
-### RAPIDS 0.10 Images
-
-#### Ubuntu 16.04
-
-All `ubuntu16.04` images use `gcc 5.4`
-
-**CUDA 9.2**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.10-cuda9.2-devel-ubuntu16.04-py3.6` | devel | 3.6 |
-| `0.10-cuda9.2-devel-ubuntu16.04-py3.7` | devel | 3.7 |
-
-**CUDA 10.0**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.10-cuda10.0-devel-ubuntu16.04-py3.6` | devel | 3.6 |
-| `0.10-cuda10.0-devel-ubuntu16.04-py3.7` | devel | 3.7 |
-
-**CUDA 10.1**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.10-cuda10.1-devel-ubuntu16.04-py3.6` | devel | 3.6 |
-| `0.10-cuda10.1-devel-ubuntu16.04-py3.7` | devel | 3.7 |
-
-#### Ubuntu 18.04
-
-All `ubuntu18.04` images use `gcc 7.3`
-
-**CUDA 9.2**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.10-cuda9.2-devel-ubuntu18.04-py3.6` | devel | 3.6 |
-| `0.10-cuda9.2-devel-ubuntu18.04-py3.7` | devel | 3.7 |
-
-**CUDA 10.0**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.10-cuda10.0-devel-ubuntu18.04-py3.6` | devel | 3.6 |
-| `0.10-cuda10.0-devel-ubuntu18.04-py3.7` | devel | 3.7 |
-
-**CUDA 10.1**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.10-cuda10.1-devel-ubuntu18.04-py3.6` | devel | 3.6 |
-| `0.10-cuda10.1-devel-ubuntu18.04-py3.7` | devel | 3.7 |
-
-#### CentOS 7
-
-All `centos7` images use `gcc 7.3`
-
-**CUDA 9.2**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.10-cuda9.2-devel-centos7-py3.6` | devel | 3.6 |
-| `0.10-cuda9.2-devel-centos7-py3.7` | devel | 3.7 |
-
-**CUDA 10.0**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.10-cuda10.0-devel-centos7-py3.6` | devel | 3.6 |
-| `0.10-cuda10.0-devel-centos7-py3.7` | devel | 3.7 |
-
-**CUDA 10.1**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.10-cuda10.1-devel-centos7-py3.6` | devel | 3.6 |
-| `0.10-cuda10.1-devel-centos7-py3.7` | devel | 3.7 |

--- a/doc/Dockerhub_rapidsai-dev.md
+++ b/doc/Dockerhub_rapidsai-dev.md
@@ -67,7 +67,7 @@ The tag naming scheme for RAPIDS images incorporates key platform details into t
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04-py3.6-py3.6
+$ docker pull rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04-py3.6
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          rapidsai/rapidsai-dev:0.10-cuda9.2-devel-ubuntu16.04-py3.6
 ```

--- a/doc/Dockerhub_rapidsai-nightly.md
+++ b/doc/Dockerhub_rapidsai-nightly.md
@@ -6,28 +6,24 @@
 
 Visit [rapids.ai](http://rapids.ai) for more information.
 
-The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes that GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
+The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
 
 **NOTE:** Review our [prerequisites](#prerequisites) section to ensure your system meets the minimum requirements for RAPIDS.
 
-## What are RAPIDS NIGHTLY containers?
+## What are RAPIDS NIGHTLY images?
 
-The `rapidsai/rapidsai-nightly` repo contains nightly docker builds of the latest WIP builds of the next release. These containers are considered generally to be unstable and should only be used for development and testing. For our latest stable release please use the [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai) containers.
+The `rapidsai/rapidsai-nightly` repo contains nightly docker builds of the latest WIP changes merged into Github repos throughout the day for the next RAPIDS release. These containers are generally considered unstable, and should only be used for development and testing. For our latest stable release, please use the [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai) containers.
 
-### Current Version
+#### RAPIDS 0.12 - 4 February 2020
 
-<!-- Replace with description of what is in a nightly, and how to read tags -->
+Versions of libraries included in the `0.12` images:
+- `cuDF` [v0.12.0](https://github.com/rapidsai/cudf/tree/v0.12.0), `cuML` [v0.12.0](https://github.com/rapidsai/cuml/tree/v0.12.0), `cuGraph` [v0.12.0](https://github.com/rapidsai/cugraph/tree/v0.12.0), `RMM` [v0.12.0](https://github.com/rapidsai/RMM/tree/v0.12.0), `cuSpatial` [v0.12.0](https://github.com/rapidsai/cuspatial/tree/v0.12.0), `cuxfilter` [v0.12.0](https://github.com/rapidsai/cuxfilter/tree/branch-0.12)
+- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.12-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.12)
 
-#### RAPIDS 0.9.0a - WIP v0.9 release
-Versions of libraries included in the `0.9` [images](#rapids-0-9-images):
-- `cuDF` [branch-0.9](https://github.com/rapidsai/cudf/tree/branch-0.9), `cuML` [branch-0.9](https://github.com/rapidsai/cuml/tree/branch-0.9), `RMM` [branch-0.9](https://github.com/rapidsai/RMM/tree/branch-0.9), `cuGraph` [branch-0.9](https://github.com/rapidsai/cugraph/tree/branch-0.9)
-- `xgboost` [cudf-interop](https://github.com/rapidsai/xgboost/tree/cudf-interop), `dask-xgboost` [dask-cudf](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf), `dask-cudf` [branch-0.9](https://github.com/rapidsai/dask-cudf/tree/branch-0.9), `dask-cuda` [branch-0.9](https://github.com/rapidsai/dask-cuda/tree/branch-0.9)
+### Image Types
 
-### Tags
-
-The RAPIDS image is based on [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda).
-This means it is a drop-in replacement, making it easy to gain the RAPIDS
-libraries while maintaining support for existing CUDA applications.
+The RAPIDS images are based on [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda), and are intended to be drop-in replacements for the corresponding CUDA
+images in order to make it easy to add RAPIDS libraries while maintaining support for existing CUDA applications.
 
 RAPIDS images come in three types, distributed in two different repos:
 
@@ -38,20 +34,11 @@ This repo (rapidsai-nightly), contains the following:
 The [rapidsai/rapidsai-dev-nightly](https://hub.docker.com/r/rapidsai/rapidsai-dev-nightly/tags) repo adds the following:
 - `devel` - contains the full RAPIDS source tree, pre-built with all artifacts in place, and the compiler toolchain, the debugging tools, the headers and the static libraries for RAPIDS development. <b>Use this image to develop RAPIDS from source.</b>
 
-#### Common Tags
+### Image Tag Naming Scheme
 
-For most users, the `runtime` image will be sufficient to get started with RAPIDS,
-you can use the following tags to pull the latest stable image:
-- `latest` or `cuda9.2-runtime-ubuntu16.04` <br/>with `gcc 5.4` and `Python 3.6`
-- `cuda10.0-runtime-ubuntu16.04`<br/>with `gcc 7.3` and `Python 3.6`
-
-#### Tag Naming Scheme
-
-Using the image types [above](#tags) `base`, `runtime`, or `devel` we use the following
-tag naming scheme for RAPIDS images:
-
+The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.9-cuda9.2-devel-ubuntu16.04-py3.6
+0.9-cuda9.2-runtime-ubuntu16.04-py3.6
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -59,6 +46,13 @@ tag naming scheme for RAPIDS images:
  |                     |
  RAPIDS version        linux version
 ```
+
+To get the latest RAPIDS version of a specific platform combination, simply exclude the RAPIDS version.  For example, to pull the latest version of RAPIDS for the `runtime` image with support for CUDA 10.1, Python 3.6, and Ubuntu 18.04, use the following tag:
+```
+cuda10.1-runtime-ubuntu18.04-py3.6
+```
+
+Many users do not need a specific platform combination but would like to ensure they're getting the latest version of RAPIDS, so as an additional convenience, a tag named simply `latest` is also provided which is equivalent to `cuda9.2-runtime-ubuntu16.04-py3.6`.
 
 ## Prerequisites
 

--- a/doc/Dockerhub_rapidsai.md
+++ b/doc/Dockerhub_rapidsai.md
@@ -10,95 +10,53 @@ The RAPIDS suite of software libraries gives you the freedom to execute end-to-e
 
 ### Current Version
 
-#### RAPIDS 0.10 - 17 October 2019
+#### RAPIDS 0.12 - 4 February 2020
 
-Versions of libraries included in the `0.10` [images](#rapids-10-images):
-- `cuDF` [v0.10.0](https://github.com/rapidsai/cudf/tree/v0.10.0), `cuML` [v0.10.0](https://github.com/rapidsai/cuml/tree/v0.10.0), `cuGraph` [v0.10.0](https://github.com/rapidsai/cugraph/tree/v0.10.0), `RMM` [v0.10.0](https://github.com/rapidsai/RMM/tree/v0.10.0), `cuSpatial` [v0.10.0](https://github.com/rapidsai/cuspatial/tree/v0.10.0)
-- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.10-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.10)
+Versions of libraries included in the `0.12` images:
+- `cuDF` [v0.12.0](https://github.com/rapidsai/cudf/tree/v0.12.0), `cuML` [v0.12.0](https://github.com/rapidsai/cuml/tree/v0.12.0), `cuGraph` [v0.12.0](https://github.com/rapidsai/cugraph/tree/v0.12.0), `RMM` [v0.12.0](https://github.com/rapidsai/RMM/tree/v0.12.0), `cuSpatial` [v0.12.0](https://github.com/rapidsai/cuspatial/tree/v0.12.0), `cuxfilter` [v0.12.0](https://github.com/rapidsai/cuxfilter/tree/branch-0.12)
+- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.12-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.12)
 
-Updates & changes
-- Added cuSpatial, the GPU-accelerated spatial and trajectory data management and analytics library.
-- Added support for CUDA 10.1.
-- Updated containers with `v0.10.0` release of cuDF, cuML, cuGraph, cuStrings, and RMM, as well as updated versions of xgboost, dask-xgboost, and dask-cuda.
+### Former Version
 
-### Former Versions
+#### RAPIDS 0.11 - 11 December 2019
 
-#### RAPIDS 0.9 - 23 August 2019
+Versions of libraries included in the `0.11` images:
+- `cuDF` [v0.11.0](https://github.com/rapidsai/cudf/tree/v0.11.0), `cuML` [v0.11.0](https://github.com/rapidsai/cuml/tree/v0.11.0), `cuGraph` [v0.11.0](https://github.com/rapidsai/cugraph/tree/v0.11.0), `RMM` [v0.11.0](https://github.com/rapidsai/RMM/tree/v0.11.0), `cuSpatial` [v0.11.0](https://github.com/rapidsai/cuspatial/tree/v0.11.0)
+- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.11-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.11)
 
-Versions of libraries included in the `0.9` [images](#rapids-09-images):
-- `cuDF` [v0.9.0](https://github.com/rapidsai/cudf/tree/v0.9.0), `cuML` [v0.9.1](https://github.com/rapidsai/cuml/tree/v0.9.1), `cuGraph` [v0.9.0](https://github.com/rapidsai/cugraph/tree/v0.9.0), `RMM` [v0.9.0](https://github.com/rapidsai/RMM/tree/v0.9.0)
-- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/cudf-interop), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.8)
+### Image Types
 
-Updates & changes
-- Updated containers with the `v0.9.1` release of cuML and the `v0.9.0` release of cuDF, cuGraph, cuStrings, RMM, and dask-cuda.
+The RAPIDS images are based on [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda), and are intended to be drop-in replacements for the corresponding CUDA
+images in order to make it easy to add RAPIDS libraries while maintaining support for existing CUDA applications.
 
-#### RAPIDS 0.8 - 28 June 2019
+RAPIDS images come in three types, distributed in two different repos:
 
-Versions of libraries included in the `0.8` [images](#rapids-08-images):
-- `cuDF` [v0.8.0](https://github.com/rapidsai/cudf/tree/v0.8.0), `cuML` [v0.8.0](https://github.com/rapidsai/cuml/tree/v0.8.0), `cuGraph` [v0.8.1](https://github.com/rapidsai/cugraph/tree/v0.8.1), `RMM` [v0.8.0](https://github.com/rapidsai/RMM/tree/v0.8.0)
-- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/cudf-interop), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf), `dask-cudf` [branch](https://github.com/rapidsai/dask-cudf/tree/branch-0.8), `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.8)
+This repo (rapidsai), contains the following:
+- `base` - contains a RAPIDS environment ready for use. <b>Use this image if you want to use RAPIDS as a part of your pipeline.</b>
+- `runtime` - extends the `base` image by adding a notebook server and example notebooks. <b>Use this image if you want to explore RAPIDS through notebooks and examples.</b>
 
-Updates & changes
-- Updated containers with `v0.8.1` release of cuGraph and `v0.8.0` release of cuDF, cuML, cuStrings, RMM, dask-cuda, dask-cudf, and dask-cuml.
+The [rapidsai/rapidsai-dev](https://hub.docker.com/r/rapidsai/rapidsai-dev/tags) repo adds the following:
+- `devel` - contains the full RAPIDS source tree, pre-built with all artifacts in place, and the compiler toolchain, the debugging tools, the headers and the static libraries for RAPIDS development. <b>Use this image to develop RAPIDS from source.</b>
 
-#### RAPIDS 0.7 - 16 May 2019
+### Image Tag Naming Scheme
 
-Versions of libraries included in the `0.7` [images](#rapids-07-images):
-- `cuDF` [v0.7.2](https://github.com/rapidsai/cudf/tree/v0.7.2), `cuML` [v0.7.0](https://github.com/rapidsai/cuml/tree/v0.7.0), `cuGraph` [v0.7.0](https://github.com/rapidsai/cugraph/tree/v0.7.0), `RMM` [v0.7.0](https://github.com/rapidsai/RMM/tree/v0.7.0)
-- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/cudf-interop), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf), `dask-cudf` [branch](https://github.com/rapidsai/dask-cudf/tree/branch-0.7), `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.7)
+The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
+```
+0.9-cuda9.2-runtime-ubuntu16.04-py3.6
+ ^       ^    ^        ^         ^
+ |       |    type     |         python version
+ |       |             |
+ |       cuda version  |
+ |                     |
+ RAPIDS version        linux version
+```
 
-Updates & changes
-- Updated containers with `v0.7.2` release of cuDf and `v0.7.0` release of cuML, cuGraph, cuStrings, RMM, dask-cuda, dask-cudf, and dask-cuml.
-- Added example notebooks for cuGraph and additional cuML example notebooks in the `runtime` & `devel` containers
+To get the latest RAPIDS version of a specific platform combination, simply exclude the RAPIDS version.  For example, to pull the latest version of RAPIDS for the `runtime` image with support for CUDA 10.1, Python 3.6, and Ubuntu 18.04, use the following tag:
+```
+cuda10.1-runtime-ubuntu18.04-py3.6
+```
 
-#### RAPIDS 0.6 - 28 Mar 2019
-
-Versions of libraries included in the `0.6` [images](#rapids-06-images):
-- `cuDF` [v0.6.1](https://github.com/rapidsai/cudf/tree/v0.6.1), `cuML` [v0.6.0](https://github.com/rapidsai/cuml/tree/v0.6.0), `cuGraph` [v0.6.0](https://github.com/rapidsai/cugraph/tree/v0.6.0), `RMM` [v0.6.0](https://github.com/rapidsai/RMM/tree/v0.6.0)
-- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/cudf-interop), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf), `dask-cudf` [branch](https://github.com/rapidsai/dask-cudf), `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
-
-#### RAPIDS 0.5.1 - 26 Feb 2019
-
-`0.5` [image list](#rapids-05-images)
-
-Versions of libraries included in the `0.5` [images](#rapids-05-images):
-- `cuDF` [v0.5.1](https://github.com/rapidsai/cudf/tree/v0.5.1), `cuML` [v0.5.1](https://github.com/rapidsai/cuml/tree/v0.5.1), `RMM` [v0.5.0](https://github.com/rapidsai/RMM/tree/v0.5.0)
-- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/cudf-mnmg-abi), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf), `dask-cudf` [branch](https://github.com/rapidsai/dask-cudf), `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda)
-
-Updates & changes
-- Added [CentOS 7 images](#centos-7)
-- Reduced the number of example notebooks in the `runtime/devel` containers
-- Updated containers with `v0.5.1` release of cuDf & cuML
-
-#### RAPIDS 0.4 - 05 Dec 2018
-
-`0.4` [image list](#rapids-04-images)
-
-Versions of libraries included in the `0.4` [images](#rapids-04-images):
-- `cuDF` [v0.4.0](https://github.com/rapidsai/cudf/tree/v0.4.0), `cuML` [v0.4.0](https://github.com/rapidsai/cuml/tree/v0.4.0)
-- `xgboost`, `dask-xgboost`, `dask-cudf`
-
-### Tags
-
-The RAPIDS image is based on the `runtime` [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda) image. This means it is a drop-in replacement, making it easy to gain the RAPIDS libraries while maintaining support for existing CUDA applications.
-
-RAPIDS images in this repo come in two types:
-
-- `base` - contains a RAPIDS environment ready for use.<br/>Use this image if you want to use RAPIDS as a part of your pipeline.
-- `runtime` - extends the `base` image by adding a notebook server and example notebooks.<br/>Use this image if you want to explore RAPIDS through notebooks and examples.
-
-<i>NOTE: for images containing the full RAPIDS source tree, pre-built with all artifacts in place, and the compiler toolchain, the debugging tools, the headers and the static libraries for RAPIDS development, use the `devel` images in the [rapidsai/rapidsai-dev](https://hub.docker.com/r/rapidsai/rapidsai-dev/tags) repo.</i>
-
-#### Common Tags
-
-For most users the `runtime` image will be sufficient to get started with RAPIDS,
-you can use the following tags to pull the latest stable image:
-- `latest` or `cuda9.2-runtime-ubuntu16.04` <br/>with `gcc 5.4` and `Python 3.6`
-- `cuda10.0-runtime-ubuntu18.04`<br/>with `gcc 7.3` and `Python 3.6`
-
-#### Other Tags
-
-View the full [tag list](#full-tag-list) for all available images.
+Many users do not need a specific platform combination but would like to ensure they're getting the latest version of RAPIDS, so as an additional convenience, a tag named simply `latest` is also provided which is equivalent to `cuda9.2-runtime-ubuntu16.04-py3.6`.
 
 ## Prerequisites
 
@@ -114,19 +72,19 @@ View the full [tag list](#full-tag-list) for all available images.
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04
+$ docker pull rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04-py3.6
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04
-         ```
-         **NOTE:** This will open a shell with [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) running in the background on port 8888 on your host machine.
+         rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04-py3.6
+```
+**NOTE:** This will open a shell with [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) running in the background on port 8888 on your host machine.
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04
+$ docker pull rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04-py3.6
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04
-         ```
-         **NOTE:** This will open a shell with [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) running in the background on port 8888 on your host machine.
+         rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04-py3.6
+```
+**NOTE:** This will open a shell with [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) running in the background on port 8888 on your host machine.
 
 ### Use JupyterLab to Explore the Notebooks
 
@@ -148,16 +106,16 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04
-                  ```
+                  rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04-py3.6
+```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04
-                  ```
-                  This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
+                  rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04-py3.6
+```
+This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 
 ### Access Documentation within Notebooks
 
@@ -184,391 +142,3 @@ Please submit issues with the container to this GitHub repository: [https://gith
 For issues with RAPIDS libraries like cuDF, cuML, RMM, or others file an issue in the related GitHub project.
 
 Additional help can be found on [Stack Overflow](https://stackoverflow.com/tags/rapids) or [Google Groups](https://groups.google.com/forum/#!forum/rapidsai).
-
-## Full Tag List
-
-Using the image types [above](#tags) `base`, or `runtime` we use the following
-tag naming scheme for RAPIDS images:
-
-```
-0.10-cuda9.2-runtime-ubuntu16.04
-^        ^    ^        ^
-|        |    type     |
-|        |             |
-|        cuda version  |
-|                      |
-RAPIDS version         linux version
-```
-
-### RAPIDS 0.10 Images
-
-#### Ubuntu 16.04
-
-All `ubuntu16.04` images use `gcc 5.4`
-
-**CUDA 9.2**
-
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda9.2-base-ubuntu16.04` | `0.10-cuda9.2-base-ubuntu16.04` | base | 3.6 |
-| `latest`<br>or<br>`cuda9.2-runtime-ubuntu16.04` | `0.10-cuda9.2-runtime-ubuntu16.04` | runtime | 3.6 |
-
-**CUDA 10.0**
-
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.0-base-ubuntu16.04` | `0.10-cuda10.0-base-ubuntu16.04` | base | 3.6 |
-| `cuda10.0-runtime-ubuntu16.04` | `0.10-cuda10.0-runtime-ubuntu16.04` | runtime | 3.6 |
-
-**CUDA 10.1**
-
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.1-base-ubuntu16.04` | `0.10-cuda10.1-base-ubuntu16.04` | base | 3.6 |
-| `cuda10.1-runtime-ubuntu16.04` | `0.10-cuda10.1-runtime-ubuntu16.04` | runtime | 3.6 |
-
-#### Ubuntu 18.04
-
-All `ubuntu18.04` images use `gcc 7.3`
-
-**CUDA 9.2**
-
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda9.2-base-ubuntu18.04` | `0.10-cuda9.2-base-ubuntu18.04` | base | 3.6 |
-| `cuda9.2-runtime-ubuntu18.04` | `0.10-cuda9.2-runtime-ubuntu18.04` | runtime | 3.6 |
-
-**CUDA 10.0**
-
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.0-base-ubuntu18.04` | `0.10-cuda10.0-base-ubuntu18.04` | base | 3.6 |
-| `cuda10.0-runtime-ubuntu18.04` | `0.10-cuda10.0-runtime-ubuntu18.04` | runtime | 3.6 |
-
-**CUDA 10.1**
-
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.1-base-ubuntu18.04` | `0.10-cuda10.1-base-ubuntu18.04` | base | 3.6 |
-| `cuda10.1-runtime-ubuntu18.04` | `0.10-cuda10.1-runtime-ubuntu18.04` | runtime | 3.6 |
-
-#### CentOS 7
-
-All `centos7` images use `gcc 7.3`
-
-**CUDA 9.2**
-
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda9.2-base-centos7` | `0.10-cuda9.2-base-centos7` | base | 3.6 |
-| `cuda9.2-runtime-centos7` | `0.10-cuda9.2-runtime-centos7` | runtime | 3.6 |
-
-**CUDA 10.0**
-
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.0-base-centos7` | `0.10-cuda10.0-base-centos7` | base | 3.6 |
-| `cuda10.0-runtime-centos7` | `0.10-cuda10.0-runtime-centos7` | runtime | 3.6 |
-
-**CUDA 10.1**
-
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.1-base-centos7` | `0.10-cuda10.1-base-centos7` | base | 3.6 |
-| `cuda10.1-runtime-centos7` | `0.10-cuda10.1-runtime-centos7` | runtime | 3.6 |
-
-### RAPIDS 0.9 Images
-
-#### Ubuntu 16.04
-
-All `ubuntu16.04` images use `gcc 5.4`
-
-**CUDA 9.2**
-
-| Short Tags | Full Tag | Image Type |
-| --- | --- | --- |
-| --- | `0.9-cuda9.2-base-ubuntu16.04` | base |
-| --- | `0.9-cuda9.2-runtime-ubuntu16.04` | runtime |
-
-**CUDA 10.0**
-
-| Short Tags | Full Tag | Image Type |
-| --- | --- | --- |
-| --- | `0.9-cuda10.0-base-ubuntu16.04` | base |
-| --- | `0.9-cuda10.0-runtime-ubuntu16.04` | runtime |
-
-#### Ubuntu 18.04
-
-All `ubuntu18.04` images use `gcc 7.3`
-
-**CUDA 9.2**
-
-| Short Tags | Full Tag | Image Type |
-| --- | --- | --- |
-| --- | `0.9-cuda9.2-base-ubuntu18.04` | base |
-| --- | `0.9-cuda9.2-runtime-ubuntu18.04` | runtime |
-
-**CUDA 10.0**
-
-| Short Tags | Full Tag | Image Type |
-| --- | --- | --- |
-| --- | `0.9-cuda10.0-base-ubuntu18.04` | base |
-| --- | `0.9-cuda10.0-runtime-ubuntu18.04` | runtime |
-
-#### CentOS 7
-
-All `centos7` images use `gcc 7.3`
-
-**CUDA 9.2**
-
-| Short Tags | Full Tag | Image Type |
-| --- | --- | --- |
-| --- | `0.9-cuda9.2-base-centos7` | base |
-| --- | `0.9-cuda9.2-runtime-centos7` | runtime |
-
-**CUDA 10.0**
-
-| Short Tags | Full Tag | Image Type |
-| --- | --- | --- |
-| --- | `0.9-cuda10.0-base-centos7` | base |
-| --- | `0.9-cuda10.0-runtime-centos7` | runtime |
-
-### RAPIDS 0.8 Images
-
-#### Ubuntu 16.04
-
-All `ubuntu16.04` images use `gcc 5.4`
-
-**CUDA 9.2**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.8-cuda9.2-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
-| `0.8-cuda9.2-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
-| `0.8-cuda9.2-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
-| `0.8-cuda9.2-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
-| `0.8-cuda9.2-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
-| `0.8-cuda9.2-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
-
-**CUDA 10.0**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.8-cuda10.0-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
-| `0.8-cuda10.0-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
-| `0.8-cuda10.0-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
-| `0.8-cuda10.0-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
-| `0.8-cuda10.0-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
-| `0.8-cuda10.0-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
-
-#### Ubuntu 18.04
-
-All `ubuntu18.04` images use `gcc 7.3`
-
-**CUDA 9.2**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.8-cuda9.2-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
-| `0.8-cuda9.2-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
-| `0.8-cuda9.2-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
-| `0.8-cuda9.2-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
-| `0.8-cuda9.2-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
-| `0.8-cuda9.2-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
-
-**CUDA 10.0**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.8-cuda10.0-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
-| `0.8-cuda10.0-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
-| `0.8-cuda10.0-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
-| `0.8-cuda10.0-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
-| `0.8-cuda10.0-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
-| `0.8-cuda10.0-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
-
-#### CentOS 7
-
-All `centos7` images use `gcc 7.3`
-
-**CUDA 9.2**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.8-cuda9.2-base-centos7-gcc7-py3.6` | base | 3.6 |
-| `0.8-cuda9.2-base-centos7-gcc7-py3.7` | base | 3.7 |
-| `0.8-cuda9.2-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
-| `0.8-cuda9.2-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
-| `0.8-cuda9.2-devel-centos7-gcc7-py3.6` | devel | 3.6 |
-| `0.8-cuda9.2-devel-centos7-gcc7-py3.7` | devel | 3.7 |
-
-**CUDA 10.0**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.8-cuda10.0-base-centos7-gcc7-py3.6` | base | 3.6 |
-| `0.8-cuda10.0-base-centos7-gcc7-py3.7` | base | 3.7 |
-| `0.8-cuda10.0-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
-| `0.8-cuda10.0-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
-| `0.8-cuda10.0-devel-centos7-gcc7-py3.6` | devel | 3.6 |
-| `0.8-cuda10.0-devel-centos7-gcc7-py3.7` | devel | 3.7 |
-
-### RAPIDS 0.7 Images
-
-#### Ubuntu 16.04
-
-All `ubuntu16.04` images use `gcc 5.4`
-
-**CUDA 9.2**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.7-cuda9.2-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
-| `0.7-cuda9.2-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
-| `0.7-cuda9.2-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
-| `0.7-cuda9.2-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
-| `0.7-cuda9.2-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
-| `0.7-cuda9.2-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
-
-**CUDA 10.0**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.7-cuda10.0-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
-| `0.7-cuda10.0-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
-| `0.7-cuda10.0-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
-| `0.7-cuda10.0-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
-| `0.7-cuda10.0-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
-| `0.7-cuda10.0-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
-
-#### Ubuntu 18.04
-
-All `ubuntu18.04` images use `gcc 7.3`
-
-**CUDA 9.2**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.7-cuda9.2-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
-| `0.7-cuda9.2-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
-| `0.7-cuda9.2-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
-| `0.7-cuda9.2-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
-| `0.7-cuda9.2-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
-| `0.7-cuda9.2-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
-
-**CUDA 10.0**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.7-cuda10.0-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
-| `0.7-cuda10.0-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
-| `0.7-cuda10.0-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
-| `0.7-cuda10.0-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
-| `0.7-cuda10.0-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
-| `0.7-cuda10.0-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
-
-#### CentOS 7
-
-All `centos7` images use `gcc 7.3`
-
-**CUDA 9.2**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.7-cuda9.2-base-centos7-gcc7-py3.6` | base | 3.6 |
-| `0.7-cuda9.2-base-centos7-gcc7-py3.7` | base | 3.7 |
-| `0.7-cuda9.2-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
-| `0.7-cuda9.2-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
-| `0.7-cuda9.2-devel-centos7-gcc7-py3.6` | devel | 3.6 |
-| `0.7-cuda9.2-devel-centos7-gcc7-py3.7` | devel | 3.7 |
-
-**CUDA 10.0**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.7-cuda10.0-base-centos7-gcc7-py3.6` | base | 3.6 |
-| `0.7-cuda10.0-base-centos7-gcc7-py3.7` | base | 3.7 |
-| `0.7-cuda10.0-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
-| `0.7-cuda10.0-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
-| `0.7-cuda10.0-devel-centos7-gcc7-py3.6` | devel | 3.6 |
-| `0.7-cuda10.0-devel-centos7-gcc7-py3.7` | devel | 3.7 |
-
-### RAPIDS 0.6 Images
-
-#### Ubuntu 16.04
-
-All `ubuntu16.04` images use `gcc 5.4`
-
-**CUDA 9.2**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.6-cuda9.2-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
-| `0.6-cuda9.2-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
-| `0.6-cuda9.2-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
-| `0.6-cuda9.2-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
-| `0.6-cuda9.2-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
-| `0.6-cuda9.2-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
-
-**CUDA 10.0**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.6-cuda10.0-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
-| `0.6-cuda10.0-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
-| `0.6-cuda10.0-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
-| `0.6-cuda10.0-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
-| `0.6-cuda10.0-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
-| `0.6-cuda10.0-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
-
-#### Ubuntu 18.04
-
-All `ubuntu18.04` images use `gcc 7.3`
-
-**CUDA 9.2**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.6-cuda9.2-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
-| `0.6-cuda9.2-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
-| `0.6-cuda9.2-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
-| `0.6-cuda9.2-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
-| `0.6-cuda9.2-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
-| `0.6-cuda9.2-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
-
-**CUDA 10.0**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.6-cuda10.0-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
-| `0.6-cuda10.0-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
-| `0.6-cuda10.0-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
-| `0.6-cuda10.0-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
-| `0.6-cuda10.0-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
-| `0.6-cuda10.0-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
-
-#### CentOS 7
-
-All `centos7` images use `gcc 7.3`
-
-**CUDA 9.2**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.6-cuda9.2-base-centos7-gcc7-py3.6` | base | 3.6 |
-| `0.6-cuda9.2-base-centos7-gcc7-py3.7` | base | 3.7 |
-| `0.6-cuda9.2-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
-| `0.6-cuda9.2-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
-| `0.6-cuda9.2-devel-centos7-gcc7-py3.6` | devel | 3.6 |
-| `0.6-cuda9.2-devel-centos7-gcc7-py3.7` | devel | 3.7 |
-
-**CUDA 10.0**
-
-| Full Tag | Image Type | Python Version |
-| --- | --- | --- |
-| `0.6-cuda10.0-base-centos7-gcc7-py3.6` | base | 3.6 |
-| `0.6-cuda10.0-base-centos7-gcc7-py3.7` | base | 3.7 |
-| `0.6-cuda10.0-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
-| `0.6-cuda10.0-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
-| `0.6-cuda10.0-devel-centos7-gcc7-py3.6` | devel | 3.6 |
-| `0.6-cuda10.0-devel-centos7-gcc7-py3.7` | devel | 3.7 |


### PR DESCRIPTION
This PR updates the build docs for the `0.12` release. The existing `readme.md`s were copied from the `rapidsai` org @ https://hub.docker.com/repositories and the `Current Version` and `Former Version` sections were all updated to include `0.12` and `0.11` respectively.

**Note:**

The docs include the mention of `cuxfilter` which hasn't yet been added to the container builds. I'll open a separate PR to add `cuxfilter` before this is merged.