### PR TITLE
Update Runtime base images

### DIFF
--- a/templates/docker/Dockerfile_centos7-runtime.template
+++ b/templates/docker/Dockerfile_centos7-runtime.template
@@ -7,7 +7,7 @@
 # Copyright (c) 2019, NVIDIA CORPORATION.
 
 
-ARG RAPIDS_REPO=rapidsai/rapidsai-nightly
+ARG RAPIDS_REPO=rapidsai/rapidsai-nightly-staging
 ARG RAPIDS_VERSION=0.13
 ARG CUDA_VERSION=10.1
 ARG CUDA_MAJORMINOR_VERSION=${CUDA_VERSION}

--- a/templates/docker/Dockerfile_ubuntu-runtime.template
+++ b/templates/docker/Dockerfile_ubuntu-runtime.template
@@ -7,7 +7,7 @@
 # Copyright (c) 2019, NVIDIA CORPORATION.
 
 
-ARG RAPIDS_REPO=rapidsai/rapidsai-nightly
+ARG RAPIDS_REPO=rapidsai/rapidsai-nightly-staging
 ARG RAPIDS_VERSION=0.13
 ARG CUDA_VERSION=10.1
 ARG CUDA_MAJORMINOR_VERSION=${CUDA_VERSION}


### PR DESCRIPTION
This PR updates the `base` image repo for our runtime images. Since the latest RAPIDS `base` images now get pushed to staging first, the `runtime` images must pull from the staging repo instead of the prod repo in order to get the latest `base` image.

Here's a quick screenshot of the images correctly pulling from the staging repo after these changes were made.

![image](https://user-images.githubusercontent.com/7400326/76109629-d45a7b00-5faa-11ea-995c-170fa7e8122d.png)
