### PR TITLE
Update permissions on quick template

### DIFF
--- a/templates/docker/Dockerfile_centos7-quick.template
+++ b/templates/docker/Dockerfile_centos7-quick.template
@@ -19,3 +19,5 @@ insertfile update_rapids
 
 # Build RAPIDS
 insertfile build_rapids
+
+RUN chmod -R ugo+w /opt/conda

--- a/templates/docker/Dockerfile_ubuntu-quick.template
+++ b/templates/docker/Dockerfile_ubuntu-quick.template
@@ -19,3 +19,5 @@ insertfile update_rapids
 
 # Build RAPIDS
 insertfile build_rapids
+
+RUN chmod -R ugo+w /opt/conda


### PR DESCRIPTION
This PR updates the permissions in `/opt/conda` for `quick` builds. This is needed since the `quick` builds perform conda operations which modifiy the permissions in `/opt/conda` subdirectories.