### PR TITLE
add conda retry interval -> 30s

### DIFF
--- a/templates/docker/conda_install_devel_deps
+++ b/templates/docker/conda_install_devel_deps
@@ -8,11 +8,11 @@ RUN source activate rapids \
     && conda list --show-channel-urls
 
 # Install rapids-build-env from conda meta-pkg
-RUN ${RAPIDS_DIR}/utils/condaretry install -y -n rapids --freeze-installed \
+RUN ${RAPIDS_DIR}/utils/condaretry --condaretry_sleep_interval=30s install -y -n rapids --freeze-installed \
         rapids-build-env=${RAPIDS_CONDA_VERSION_SPEC}
 
 # Install rapids-doc-env from conda meta-pkg
-RUN ${RAPIDS_DIR}/utils/condaretry install -y -n rapids --freeze-installed \
+RUN ${RAPIDS_DIR}/utils/condaretry --condaretry_sleep_interval=30s install -y -n rapids --freeze-installed \
         rapids-doc-env=${RAPIDS_CONDA_VERSION_SPEC}
 
 # Env debug info

--- a/templates/docker/conda_install_notebookenv
+++ b/templates/docker/conda_install_notebookenv
@@ -6,7 +6,7 @@ RUN source activate rapids \
     && conda list --show-channel-urls
 
 # Install the rapids-notebook-env meta-pkg
-RUN ${RAPIDS_DIR}/utils/condaretry install -y -n rapids --freeze-installed \
+RUN ${RAPIDS_DIR}/utils/condaretry --condaretry_sleep_interval=30s install -y -n rapids --freeze-installed \
         rapids-notebook-env=${RAPIDS_CONDA_VERSION_SPEC} \
    && conda clean -afy \
    && chmod -R ugo+w /opt/conda

--- a/templates/docker/conda_install_rapids
+++ b/templates/docker/conda_install_rapids
@@ -5,7 +5,7 @@ RUN source activate rapids \
     && conda info \
     && conda config --show-sources \
     && conda list --show-channel-urls \
-    && ${RAPIDS_DIR}/utils/condaretry install -y -n rapids --freeze-installed \
+    && ${RAPIDS_DIR}/utils/condaretry --condaretry_sleep_interval=30s install -y -n rapids --freeze-installed \
       cudatoolkit=${CUDA_MAJORMINOR_VERSION} \
       rapids=${RAPIDS_CONDA_VERSION_SPEC} \
    && conda clean -afy \

--- a/templates/docker/unused/conda_install_devel
+++ b/templates/docker/unused/conda_install_devel
@@ -4,7 +4,7 @@ ENV NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
 
 COPY supportfiles/.condarc /opt/conda/.condarc
 
-RUN ${RAPIDS_DIR}/utils/condaretry install -y --freeze-installed conda-build \
+RUN ${RAPIDS_DIR}/utils/condaretry --condaretry_sleep_interval=30s install -y --freeze-installed conda-build \
     && source activate rapids \
     && env \
     && pip install sphinx-markdown-tables \
@@ -13,7 +13,7 @@ RUN ${RAPIDS_DIR}/utils/condaretry install -y --freeze-installed conda-build \
     && conda list --show-channel-urls \
     && conda remove -y \
          nomkl \
-    && ${RAPIDS_DIR}/utils/condaretry install -y -n rapids --freeze-installed \
+    && ${RAPIDS_DIR}/utils/condaretry --condaretry_sleep_interval=30s install -y -n rapids --freeze-installed \
       black \
       boost-cpp=${BOOST_CPP_VERSION} \
       cmake=${CMAKE_VERSION} \

--- a/templates/docker/unused/conda_install_rapids_deps
+++ b/templates/docker/unused/conda_install_rapids_deps
@@ -12,7 +12,7 @@ RUN source activate rapids \
     && conda info \
     && conda config --show-sources \
     && conda list --show-channel-urls \
-    && ${RAPIDS_DIR}/utils/condaretry install -y -n rapids --freeze-installed --override-channels --only-deps \
+    && ${RAPIDS_DIR}/utils/condaretry --condaretry_sleep_interval=30s install -y -n rapids --freeze-installed --override-channels --only-deps \
       -c rapidsai \
       -c rapidsai-nightly \
       -c nvidia \


### PR DESCRIPTION
This PR increases the default conda retry interval to 30s to account for the amount of conda errors we've been seeing in base builds lately.