### PR TITLE
Fix gcc 7 update issues

### DIFF
--- a/templates/docker/gcc7_centos7
+++ b/templates/docker/gcc7_centos7
@@ -1,26 +1,3 @@
-##TODO-mwendt I don't think we need NCCL installed and most of these pkgs are installed
-###
-### The support dir contains RPMs that enable additional repos needed
-### for CentOS (among other things). Copy them to a temp dir and remove
-### after installed.
-###
-##COPY supportfiles/*.rpm /tmp
-##
-##RUN yum install -y /tmp/*.rpm && \
-##    rm -rf /tmp/*.rpm && \
-##    yum upgrade -y && \
-##    yum install -y \
-##      bzip2 \
-##      curl \
-##      git \
-##      screen \
-##      vim \
-##      wget \
-##      which \
-##      libnccl-2.4.2-1+cuda${CUDA_MAJORMINOR_VERSION} \
-##      libnccl-devel-2.4.2-1+cuda${CUDA_MAJORMINOR_VERSION} \
-##      libnccl-static-2.4.2-1+cuda${CUDA_MAJORMINOR_VERSION}
-
 # Install gcc7 from prebuilt image
 COPY --from=gpuci/builds-gcc7:10.0-devel-centos7 /usr/local/gcc7 /usr/local/gcc7
 

--- a/templates/docker/gcc7_ubuntu
+++ b/templates/docker/gcc7_ubuntu
@@ -1,10 +1,3 @@
-# Update and add pkgs
-RUN apt-get update \
-    && apt-get install -y \
-      gcc-${CC_VERSION} \
-      g++-${CXX_VERSION} \
-    && rm -rf /var/lib/apt/lists/*
-
 # Update environment to use new gcc
 ENV CC=/usr/bin/gcc-${CC_VERSION}
 ENV CXX=/usr/bin/g++-${CXX_VERSION}


### PR DESCRIPTION
This fixes a problem for Ubuntu 18.04 where gcc was being updated to 7.5 from the `nvidia/cuda` version of 7.4. With 7.5 there are conflicts with GDAL and CUDA in cuspatial. Instead of updating our version of gcc in Ubuntu we are now relying on the version installed by `nvidia-cuda` containers