### PR TITLE
[REVIEW] Convert notebooks into working directory

### DIFF
--- a/utils/nbtest.sh
+++ b/utils/nbtest.sh
@@ -28,13 +28,13 @@ for nb in $*; do
     NBFILENAME=$1
     NBNAME=${NBFILENAME%.*}
     NBNAME=${NBNAME##*/}
-    NBTESTSCRIPT=/${NBDIR}/${NBNAME}-test.py
+    NBTESTSCRIPT=${NBDIR}/${NBNAME}-test.py
     shift
 
     echo --------------------------------------------------------------------------------
     echo STARTING: ${NBNAME}
     echo --------------------------------------------------------------------------------
-    jupyter nbconvert --to script ${NBFILENAME} --output /${NBDIR}/${NBNAME}-test
+    jupyter nbconvert --to script ${NBFILENAME} --output ${NBDIR}/${NBNAME}-test
     echo "${MAGIC_OVERRIDE_CODE}" > /tmp/tmpfile
     cat ${NBTESTSCRIPT} >> /tmp/tmpfile
     mv /tmp/tmpfile ${NBTESTSCRIPT}

--- a/utils/nbtest.sh
+++ b/utils/nbtest.sh
@@ -22,18 +22,19 @@ get_ipython().run_cell_magic=my_run_cell_magic
 
 NO_COLORS=--colors=NoColor
 EXITCODE=0
+NBDIR=${PWD}
 
 for nb in $*; do
     NBFILENAME=$1
     NBNAME=${NBFILENAME%.*}
     NBNAME=${NBNAME##*/}
-    NBTESTSCRIPT=/tmp/${NBNAME}-test.py
+    NBTESTSCRIPT=/${NBDIR}/${NBNAME}-test.py
     shift
 
     echo --------------------------------------------------------------------------------
     echo STARTING: ${NBNAME}
     echo --------------------------------------------------------------------------------
-    jupyter nbconvert --to script ${NBFILENAME} --output /tmp/${NBNAME}-test
+    jupyter nbconvert --to script ${NBFILENAME} --output /${NBDIR}/${NBNAME}-test
     echo "${MAGIC_OVERRIDE_CODE}" > /tmp/tmpfile
     cat ${NBTESTSCRIPT} >> /tmp/tmpfile
     mv /tmp/tmpfile ${NBTESTSCRIPT}


### PR DESCRIPTION
Some of our repos use datasets in their notebooks which are referenced using relative paths. This change makes the python scripts generated from `nbconvert` to be placed into the working directory. This guarantees that any relative paths stay consistent.

In the test script that calls this, there is already a `cd` command into the notebook's directory before running, which will avoid any issues involving working directory. https://github.com/rapidsai/build/blob/branch-0.14/supportfiles/test.sh#L49