### PR TITLE
Use New Staging Repo

### DIFF
--- a/templates/docker/Dockerfile_centos7-quick.template
+++ b/templates/docker/Dockerfile_centos7-quick.template
@@ -12,7 +12,7 @@ ARG LINUX_VERSION=centos7
 ARG PYTHON_VERSION=3.7
 ARG VERSION=0.14
 
-FROM rapidsai/rapidsai-dev-nightly-staging:${VERSION}-cuda${CUDA_VERSION}-devel-${LINUX_VERSION}-py${PYTHON_VERSION}
+FROM rapidsaistaging/rapidsai-dev-nightly-staging:${VERSION}-cuda${CUDA_VERSION}-devel-${LINUX_VERSION}-py${PYTHON_VERSION}
 
 # Update RAPIDS repos
 insertfile update_rapids

--- a/templates/docker/Dockerfile_centos7-runtime.template
+++ b/templates/docker/Dockerfile_centos7-runtime.template
@@ -7,7 +7,7 @@
 # Copyright (c) 2019, NVIDIA CORPORATION.
 
 
-ARG RAPIDS_REPO=rapidsai/rapidsai-nightly-staging
+ARG RAPIDS_REPO=rapidsaistaging/rapidsai-nightly-staging
 ARG RAPIDS_VERSION=0.14
 ARG CUDA_VERSION=10.1
 ARG CUDA_MAJORMINOR_VERSION=${CUDA_VERSION}

--- a/templates/docker/Dockerfile_ubuntu-quick.template
+++ b/templates/docker/Dockerfile_ubuntu-quick.template
@@ -12,7 +12,7 @@ ARG LINUX_VERSION=ubuntu18.04
 ARG PYTHON_VERSION=3.7
 ARG VERSION=0.14
 
-FROM rapidsai/rapidsai-dev-nightly-staging:${VERSION}-cuda${CUDA_VERSION}-devel-${LINUX_VERSION}-py${PYTHON_VERSION}
+FROM rapidsaistaging/rapidsai-dev-nightly-staging:${VERSION}-cuda${CUDA_VERSION}-devel-${LINUX_VERSION}-py${PYTHON_VERSION}
 
 # Update RAPIDS repos
 insertfile update_rapids

--- a/templates/docker/Dockerfile_ubuntu-runtime.template
+++ b/templates/docker/Dockerfile_ubuntu-runtime.template
@@ -7,7 +7,7 @@
 # Copyright (c) 2019, NVIDIA CORPORATION.
 
 
-ARG RAPIDS_REPO=rapidsai/rapidsai-nightly-staging
+ARG RAPIDS_REPO=rapidsaistaging/rapidsai-nightly-staging
 ARG RAPIDS_VERSION=0.14
 ARG CUDA_VERSION=10.1
 ARG CUDA_MAJORMINOR_VERSION=${CUDA_VERSION}


### PR DESCRIPTION
This PR updates the staging repo used by our Docker images. We chose to separate our staging repos into a different DockerHub organization so that they didn't confuse end-users. Additionally, using private repos in our production DockerHub organization didn't work well with the [remote-docker-plugin](https://github.com/gpuopenanalytics/remote-docker-plugin).

Link to new DockerHub staging repo: https://hub.docker.com/u/rapidsaistaging