### PR TITLE
Add cuml_benchmarks exception to notebook tests

### DIFF
--- a/supportfiles/test.sh
+++ b/supportfiles/test.sh
@@ -7,7 +7,7 @@ NOTEBOOKS_DIR=${RAPIDS_DIR}/notebooks
 
 # Add notebooks that should be skipped here
 # (space-separated list of filenames without paths)
-SKIPNBS=""
+SKIPNBS="cuml_benchmarks-test.py"
 
 ## Check env
 env


### PR DESCRIPTION
This PR adds `cuml_benchmarks-test.py` to the exceptions list for notebook testing since it was causing the Jenkins job below to timeout. The `cuml` team suggested disabling it for Docker testing in the Slack thread below.

**References:**
[Jenkins job](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/nightly-tests/job/docker-test-notebooks/218/CUDA_VERSION=10.2,LINUX_VERSION=ubuntu18.04,PYTHON_VERSION=3.6/console)
[Slack thread](https://nvidia.slack.com/archives/CAL736F5W/p1589471616152100)