### PR TITLE
Remove extraneous .gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .vscode
-*.Dockerfile
 build
 
 


### PR DESCRIPTION
This PR removes an unnecessary `.gitignore` entry that is conflicting with a GitHub Action.