### PR TITLE
Add gsfonts to ubuntu-devel

### DIFF
--- a/templates/Devel.dockerfile.j2
+++ b/templates/Devel.dockerfile.j2
@@ -32,6 +32,9 @@ ENV CC=/usr/bin/gcc-${CC_VERSION}
 ENV CXX=/usr/bin/g++-${CXX_VERSION}
 ENV CUDAHOSTCXX=/usr/bin/g++-${CXX_VERSION}
 ENV PATH=${PATH}:/conda/bin
+RUN apt-get update && apt-get install -y \
+    gsfonts \
+    && rm -rf /var/lib/apt/lists/*
 {% endif %}
 
 {% if "centos" in os %}


### PR DESCRIPTION
This PR adds `gsfonts` to our ubuntu-devel images. `gsfonts` is necessary to correctly render diagram fonts in RAPIDS libraries' documentation.