### PR TITLE
Fix missing chmod in devel images

### DIFF
--- a/templates/Quick.dockerfile.j2
+++ b/templates/Quick.dockerfile.j2
@@ -23,5 +23,3 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
 
 {# Build RAPIDS #}
 {% include 'partials/devel_build.dockerfile.j2' %}
-
-RUN chmod -R ugo+w /opt/conda

--- a/templates/partials/devel_build.dockerfile.j2
+++ b/templates/partials/devel_build.dockerfile.j2
@@ -40,3 +40,5 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
 
   {% endif %}
 {% endfor %}
+
+RUN chmod -R ugo+w /opt/conda ${RAPIDS_DIR}


### PR DESCRIPTION
In our pre-Jinja devel Dockerfiles, there was a [`chmod` step at the bottom of the file](https://github.com/rapidsai/build/blob/1fef16347ee58174c8a761aca322105f067023fe/generatedDockerfiles/Dockerfile.ubuntu-devel#L180) that was necessary to prevent file permission issues. 

The step was part of the Jupyter notebooks installation process which happened to (incorrectly) appear twice in the Dockerfile ([here](https://github.com/rapidsai/build/blob/1fef16347ee58174c8a761aca322105f067023fe/generatedDockerfiles/Dockerfile.ubuntu-devel#L174-L190) and [here](https://github.com/rapidsai/build/blob/1fef16347ee58174c8a761aca322105f067023fe/generatedDockerfiles/Dockerfile.ubuntu-devel#L92-L111)).

When I removed the duplicated notebook steps at the bottom of the devel files as part of the Jinja2 migration, I inadvertently removed the `chmod` step as well.

This PR fixes that by re-adding the `chmod` step into the `devel_build.dockerfile.j2` partial which is used by both the [devel template](https://github.com/rapidsai/build/blob/branch-0.14/templates/Devel.dockerfile.j2#L106) and [quick template](https://github.com/rapidsai/build/blob/branch-0.14/templates/Quick.dockerfile.j2#L25).