### PR TITLE
Update xgboost repo/branch in branch-0.15

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -24,8 +24,8 @@ RAPIDS_LIBS:
     repo_url: https://github.com/rapidsai/cugraph.git
   - name: xgboost
     update_submodules: no
-    repo_url: https://github.com/rapidsai/xgboost.git
-    branch: rapids-0.14-release
+    repo_url: https://github.com/dmlc/xgboost.git
+    branch: v1.1.0
   - name: dask-xgboost
     repo_url: https://github.com/rapidsai/dask-xgboost.git
     branch: dask-cudf


### PR DESCRIPTION
This PR updates the `xgboost` repo and tag used for `devel` images.