### PR TITLE
Remove nvstrings build step

### DIFF
--- a/templates/partials/devel_build.dockerfile.j2
+++ b/templates/partials/devel_build.dockerfile.j2
@@ -10,7 +10,7 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   {% if lib.name == "cudf" %}
   ./build.sh -l && \
   cd cpp/build && \
-  make -j${PARALLEL_LEVEL} build_tests_cudf
+  ./build.sh tests
 
   {% elif lib.name == "cuspatial" %}
   export CUSPATIAL_HOME="$PWD" && \

--- a/templates/partials/devel_build.dockerfile.j2
+++ b/templates/partials/devel_build.dockerfile.j2
@@ -8,8 +8,6 @@ ENV PARALLEL_LEVEL=${PARALLEL_LEVEL}
 RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   source activate rapids && \
   {% if lib.name == "cudf" %}
-  ./build.sh -l && \
-  cd cpp/build && \
   ./build.sh tests
 
   {% elif lib.name == "cuspatial" %}

--- a/templates/partials/devel_build.dockerfile.j2
+++ b/templates/partials/devel_build.dockerfile.j2
@@ -10,7 +10,6 @@ RUN cd ${RAPIDS_DIR}/{{ lib.name }} && \
   {% if lib.name == "cudf" %}
   ./build.sh -l && \
   cd cpp/build && \
-  make -j${PARALLEL_LEVEL} build_tests_nvstrings && \
   make -j${PARALLEL_LEVEL} build_tests_cudf
 
   {% elif lib.name == "cuspatial" %}


### PR DESCRIPTION
This PR removes the `build_tests_nvstrings` build step from our repo. It looks like it was removed from `cudf` in PR https://github.com/rapidsai/cudf/pull/5373 and is now causing issues in our builds.